### PR TITLE
fix: change `opcode_to_instruction` not to return whole instruction

### DIFF
--- a/runnair/crates/runner/src/vm/add_ap.rs
+++ b/runnair/crates/runner/src/vm/add_ap.rs
@@ -1,15 +1,15 @@
 use paste::paste;
 use stwo_prover::core::fields::m31::M31;
 
-use super::{Instruction, State};
 use crate::memory::relocatable::assert_and_project;
 use crate::memory::{MaybeRelocatableValue, Memory};
+use crate::vm::{InstructionArgs, State};
 
 pub fn addap(state: State, summand: M31) -> State {
     State {
         ap: state.ap + summand,
         fp: state.fp,
-        pc: state.pc,
+        pc: state.pc + M31(1),
     }
 }
 
@@ -19,10 +19,10 @@ macro_rules! addap_with_operand {
             pub fn [<addap_ $operand>](
                 memory: &mut Memory,
                 state: State,
-                instruction: Instruction,
+                args: InstructionArgs,
             ) -> State {
                 if let MaybeRelocatableValue::Absolute(summand) =
-                    crate::vm::operand::$operand(memory, state, &instruction.args)
+                    crate::vm::operand::$operand(memory, state, &args)
                 {
                     addap(state, assert_and_project(summand))
                 } else {

--- a/runnair/crates/runner/src/vm/jmp.rs
+++ b/runnair/crates/runner/src/vm/jmp.rs
@@ -1,9 +1,9 @@
 use paste::paste;
 use stwo_prover::core::fields::m31::M31;
 
-use super::{Instruction, State};
 use crate::memory::relocatable::assert_and_project;
 use crate::memory::{MaybeRelocatableValue, Memory};
+use crate::vm::{InstructionArgs, State};
 
 pub fn jmp_rel(state: State, operand: M31) -> State {
     State {
@@ -43,10 +43,10 @@ macro_rules! jmp_with_operand {
             pub fn [<jmp_rel_ $operand>](
                 memory: &mut Memory,
                 state: State,
-                instruction: Instruction,
+                args: InstructionArgs,
             ) -> State {
                 if let MaybeRelocatableValue::Absolute(offset) =
-                    crate::vm::operand::$operand(memory, state, &instruction.args)
+                    crate::vm::operand::$operand(memory, state, &args)
                 {
                     jmp_rel(state, assert_and_project(offset))
                 } else {
@@ -57,10 +57,10 @@ macro_rules! jmp_with_operand {
             pub fn [<jmp_rel_ $operand _appp>](
                 memory: &mut Memory,
                 state: State,
-                instruction: Instruction,
+                args: InstructionArgs,
             ) -> State {
                 if let MaybeRelocatableValue::Absolute(offset) =
-                    crate::vm::operand::$operand(memory, state, &instruction.args)
+                    crate::vm::operand::$operand(memory, state, &args)
                 {
                     jmp_rel_appp(state, assert_and_project(offset))
                 } else {
@@ -71,10 +71,10 @@ macro_rules! jmp_with_operand {
             pub fn [<jmp_abs_ $operand>](
                 memory: &mut Memory,
                 state: State,
-                instruction: Instruction,
+                args: InstructionArgs,
             ) -> State {
                 if let MaybeRelocatableValue::Absolute(offset) =
-                    crate::vm::operand::$operand(memory, state, &instruction.args)
+                    crate::vm::operand::$operand(memory, state, &args)
                 {
                     jmp_abs(state, assert_and_project(offset))
                 } else {
@@ -85,10 +85,10 @@ macro_rules! jmp_with_operand {
             pub fn [<jmp_abs_ $operand _appp>](
                 memory: &mut Memory,
                 state: State,
-                instruction: Instruction,
+                args: InstructionArgs,
             ) -> State {
                 if let MaybeRelocatableValue::Absolute(offset) =
-                    crate::vm::operand::$operand(memory, state, &instruction.args)
+                    crate::vm::operand::$operand(memory, state, &args)
                 {
                     jmp_abs_appp(state, assert_and_project(offset))
                 } else {
@@ -117,4 +117,3 @@ jmp_with_operand!(mul_fp_ap);
 jmp_with_operand!(mul_fp_fp);
 jmp_with_operand!(mul_imm_ap);
 jmp_with_operand!(mul_imm_fp);
-

--- a/runnair/crates/runner/src/vm/mod.rs
+++ b/runnair/crates/runner/src/vm/mod.rs
@@ -24,11 +24,11 @@ pub type InstructionArgs = [M31; 3];
 
 pub struct Instruction {
     _op: M31,
-    args: InstructionArgs,
+    _args: InstructionArgs,
 }
 
 // TODO(alont): autogenerate this.
-pub fn opcode_to_instruction(opcode: usize) -> fn(&mut Memory, State, Instruction) -> State {
+pub fn opcode_to_instruction(opcode: usize) -> fn(&mut Memory, State, InstructionArgs) -> State {
     match opcode {
         0 => addap_add_ap_ap,
         1 => addap_add_ap_fp,


### PR DESCRIPTION
The opcode is resolved beforehand.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo-m31/2)
<!-- Reviewable:end -->
