### PR TITLE
Revert "feat: immediates segment (#31)"

### DIFF
--- a/crates/runnair/src/utils.rs
+++ b/crates/runnair/src/utils.rs
@@ -5,11 +5,11 @@ use stwo_prover::core::fields::qm31::QM31;
 
 // Converters.
 
-pub(crate) fn m31_from_hex_str(x: String) -> M31 {
+pub(crate) fn m31_from_hex_str(x: &str) -> M31 {
     M31(u32::from_str_radix(x.trim_start_matches("0x"), 16).unwrap())
 }
 
-pub(crate) fn qm31_from_hex_str_array(x: [String; 4]) -> QM31 {
+pub(crate) fn qm31_from_hex_str_array(x: [&str; 4]) -> QM31 {
     let m31_array = x.map(m31_from_hex_str);
     QM31::from_m31_array(m31_array)
 }

--- a/crates/runnair/src/vm/assert.rs
+++ b/crates/runnair/src/vm/assert.rs
@@ -72,7 +72,7 @@ fn assign_or_assert_operation(
 macro_rules! define_assert {
     ($dest:ident, $op1:ident, $op2:ident) => {
         paste! {
-            /// Assert add without incrementing `ap`: `assert_[ap/fp]_add_[ap/fp/imm]_[ap/fp]`.
+            /// Assert add without incrementing `ap`: `assert_[ap/fp]_add_[ap/fp]_[ap/fp]`.
             pub(crate) fn [<assert_ $dest _add_ $op1 _ $op2>] (
                 memory: &mut Memory,
                 state: State,
@@ -83,7 +83,7 @@ macro_rules! define_assert {
                 state.advance()
             }
 
-            /// Assert add with incrementing `ap`: `assert_[ap/fp]_add_[ap/fp/imm]_[ap/fp][_appp]`.
+            /// Assert add with incrementing `ap`: `assert_[ap/fp]_add_[ap/fp]_[ap/fp][_appp]`.
             pub(crate) fn [<assert_ $dest _add_ $op1 _ $op2 _appp>] (
                 memory: &mut Memory,
                 state: State,
@@ -94,7 +94,7 @@ macro_rules! define_assert {
                 state.advance_and_increment_ap()
             }
 
-            /// Assert mul without incrementing `ap`: `assert_[ap/fp]_mul_[ap/fp/imm]_[ap/fp]`.
+            /// Assert mul without incrementing `ap`: `assert_[ap/fp]_mul_[ap/fp]_[ap/fp]`.
             pub(crate) fn [<assert_ $dest _mul_ $op1 _ $op2>] (
                 memory: &mut Memory,
                 state: State,
@@ -105,7 +105,7 @@ macro_rules! define_assert {
                 state.advance()
             }
 
-            /// Assert mul with incrementing `ap`: `assert_[ap/fp]_mul_[ap/fp/imm]_[ap/fp][_appp]`.
+            /// Assert mul with incrementing `ap`: `assert_[ap/fp]_mul_[ap/fp]_[ap/fp][_appp]`.
             pub(crate) fn [<assert_ $dest _mul_ $op1 _ $op2 _appp>] (
                 memory: &mut Memory,
                 state: State,
@@ -113,6 +113,109 @@ macro_rules! define_assert {
             ) -> State {
                 let (dest, op1, op2) = (stringify!($dest), stringify!($op1), stringify!($op2));
                 assign_or_assert_operation(memory, state, Operation::Mul, &[dest, op1, op2], &args);
+                state.advance_and_increment_ap()
+            }
+        }
+    };
+}
+
+fn assign_or_assert_operation_with_imm(
+    memory: &mut Memory,
+    state: State,
+    operation: Operation,
+    bases: &[&str; 2],
+    args: &[M31; 3],
+) {
+    let [dest, op1] = bases;
+    let [dest_addr, op1_addr] = resolve_addresses(state, &[dest, op1], &[args[0], args[2]]);
+    let immediate = args[1];
+
+    match (memory.get(dest_addr), memory.get(op1_addr)) {
+        (Some(dest_val), Some(op1_val)) => {
+            assert_eq!(
+                dest_val,
+                operation.apply(op1_val, immediate),
+                "Assertion failed."
+            );
+        }
+        (None, Some(op1_val)) => {
+            memory.insert(dest_addr, operation.apply(op1_val, immediate));
+        }
+        (Some(dest_val), None) => {
+            memory.insert(op1_addr, operation.deduce(dest_val, immediate));
+        }
+        _ => panic!("Cannot deduce more than one operand"),
+    };
+}
+
+macro_rules! define_assert_with_imm {
+    ($dest:ident, $op1:ident) => {
+        paste! {
+            /// Assert add without incrementing `ap`: `assert_[ap/fp]_add_imm_[ap/fp]`.
+            pub(crate) fn [<assert_ $dest _add_imm_ $op1>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (dest, op1) = (stringify!($dest), stringify!($op1));
+                assign_or_assert_operation_with_imm(
+                    memory,
+                    state,
+                    Operation::Add,
+                    &[dest, op1],
+                    &args,
+                );
+                state.advance()
+            }
+
+            /// Assert add with incrementing `ap`: `assert_[ap/fp]_add_imm_[ap/fp][_appp]`.
+            pub(crate) fn [<assert_ $dest _add_imm_ $op1 _appp>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (dest, op1) = (stringify!($dest), stringify!($op1));
+                assign_or_assert_operation_with_imm(
+                    memory,
+                    state,
+                    Operation::Add,
+                    &[dest, op1],
+                    &args,
+                );
+                state.advance_and_increment_ap()
+            }
+
+            /// Assert mul without incrementing `ap`: `assert_[ap/fp]_mul_imm_[ap/fp]`.
+            pub(crate) fn [<assert_ $dest _mul_imm_ $op1>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (dest, op1) = (stringify!($dest), stringify!($op1));
+                assign_or_assert_operation_with_imm(
+                    memory,
+                    state,
+                    Operation::Mul,
+                    &[dest, op1],
+                    &args,
+                );
+                state.advance()
+            }
+
+            /// Assert mul with incrementing `ap`: `assert_[ap/fp]_mul_imm_[ap/fp][_appp]`.
+            pub(crate) fn [<assert_ $dest _mul_imm_ $op1 _appp>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (dest, op1) = (stringify!($dest), stringify!($op1));
+                assign_or_assert_operation_with_imm(
+                    memory,
+                    state,
+                    Operation::Mul,
+                    &[dest, op1],
+                    &args,
+                );
                 state.advance_and_increment_ap()
             }
         }
@@ -160,14 +263,14 @@ define_assert!(ap, ap, ap);
 define_assert!(ap, ap, fp);
 define_assert!(ap, fp, ap);
 define_assert!(ap, fp, fp);
-define_assert!(ap, imm, ap);
-define_assert!(ap, imm, fp);
 define_assert!(fp, ap, ap);
 define_assert!(fp, ap, fp);
 define_assert!(fp, fp, ap);
 define_assert!(fp, fp, fp);
-define_assert!(fp, imm, ap);
-define_assert!(fp, imm, fp);
+define_assert_with_imm!(ap, ap);
+define_assert_with_imm!(ap, fp);
+define_assert_with_imm!(fp, ap);
+define_assert_with_imm!(fp, fp);
 define_assert_imm!(ap);
 define_assert_imm!(fp);
 

--- a/crates/runnair/src/vm/call.rs
+++ b/crates/runnair/src/vm/call.rs
@@ -59,12 +59,28 @@ macro_rules! define_call {
     };
 }
 
+macro_rules! define_call_imm {
+    ($type:ident) => {
+        paste! {
+            pub(crate) fn [<call_ $type _imm>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                push_return_fp_and_pc(memory, state);
+                let immediate = args[0];
+                [<call_ $type>](state, immediate)
+            }
+        }
+    };
+}
+
 define_call!(abs, ap);
 define_call!(abs, fp);
-define_call!(abs, imm);
 define_call!(rel, ap);
 define_call!(rel, fp);
-define_call!(rel, imm);
+define_call_imm!(abs);
+define_call_imm!(rel);
 
 pub(crate) fn ret(memory: &mut Memory, state: State, _args: InstructionArgs) -> State {
     let Some(fp) = memory.get(state.fp - M31(2)) else {

--- a/crates/runnair/src/vm/jnz.rs
+++ b/crates/runnair/src/vm/jnz.rs
@@ -25,6 +25,21 @@ fn resolve_jnz_args(
     (assert_and_project(destination), condition)
 }
 
+fn resolve_jnz_imm_args(
+    memory: &Memory,
+    state: State,
+    base: &str,
+    offsets: &[M31; 2],
+) -> (M31, QM31) {
+    let [cond_addr] = resolve_addresses(state, &[base], &[offsets[1]]);
+    let destination = offsets[0];
+    let Some(MaybeRelocatable::Absolute(condition)) = memory.get(cond_addr) else {
+        panic!("Condition must be an absolute value.")
+    };
+
+    (destination, condition)
+}
+
 fn jnz(state: State, destination: impl Into<MaybeRelocatableAddr>, condition: impl Zero) -> State {
     if condition.is_zero() {
         state.advance()
@@ -81,9 +96,45 @@ macro_rules! define_jnz {
     };
 }
 
+macro_rules! define_jnz_imm {
+    ($dest:ident) => {
+        paste! {
+            /// Jump-not-zero without incrementing `ap`: `jnz_imm_[ap/fp]`.
+            pub(crate) fn [<jnz_imm_ $dest >] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (destination, condition) = resolve_jnz_imm_args(
+                    memory,
+                    state,
+                    stringify!($dest),
+                    &[args[0], args[1]],
+                );
+                jnz(state, destination, condition)
+            }
+
+            /// Jump-not-zero with incrementing `ap`: `jnz_imm_[ap/fp]_appp`.
+            pub(crate) fn [<jnz_imm_ $dest _appp>] (
+                memory: &mut Memory,
+                state: State,
+                args: InstructionArgs,
+            ) -> State {
+                let (destination, condition) = resolve_jnz_imm_args(
+                    memory,
+                    state,
+                    stringify!($dest),
+                    &[args[0], args[1]],
+                );
+                jnz_appp(state, destination, condition)
+            }
+        }
+    };
+}
+
 define_jnz!(ap, ap);
 define_jnz!(ap, fp);
 define_jnz!(fp, ap);
 define_jnz!(fp, fp);
-define_jnz!(imm, ap);
-define_jnz!(imm, fp);
+define_jnz_imm!(ap);
+define_jnz_imm!(fp);

--- a/crates/runnair/src/vm/mod.rs
+++ b/crates/runnair/src/vm/mod.rs
@@ -25,13 +25,10 @@ use self::jmp::*;
 use self::jnz::*;
 use crate::memory::relocatable::{MaybeRelocatable, Relocatable, Segment};
 use crate::memory::{MaybeRelocatableAddr, Memory};
-use crate::utils::{
-    get_tests_data_dir, m31_from_hex_str, maybe_resize, qm31_from_hex_str_array, u32_from_usize,
-};
+use crate::utils::{get_tests_data_dir, m31_from_hex_str, maybe_resize, u32_from_usize};
 
 // TODO: reconsider input type and parsing.
 pub(crate) type Input = serde_json::Value;
-const IMMEDIATES_SEGMENT: Segment = 2;
 
 #[derive(Clone, Copy, Debug)]
 pub struct State {
@@ -89,14 +86,12 @@ impl<T: Into<M31>> From<[T; 4]> for Instruction {
 pub struct Program {
     pub instructions: Vec<Instruction>,
     pub hints: Hints,
-    pub immediates: Vec<QM31>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ProgramRaw {
     data: Vec<[String; 4]>,
     hints: serde_json::Map<String, serde_json::Value>,
-    immediates: Vec<[String; 4]>,
 }
 
 impl TryFrom<ProgramRaw> for Program {
@@ -107,7 +102,7 @@ impl TryFrom<ProgramRaw> for Program {
             .data
             .into_iter()
             .map(|instruction| {
-                let raw_instruction = instruction.map(m31_from_hex_str);
+                let raw_instruction = instruction.map(|x| m31_from_hex_str(&x));
                 Instruction::from(raw_instruction)
             })
             .collect();
@@ -128,16 +123,9 @@ impl TryFrom<ProgramRaw> for Program {
             hints[pc] = Some(hint);
         }
 
-        let immediates: Vec<_> = raw_program
-            .immediates
-            .into_iter()
-            .map(qm31_from_hex_str_array)
-            .collect();
-
         Ok(Self {
             instructions,
             hints,
-            immediates,
         })
     }
 }
@@ -169,33 +157,34 @@ impl VM {
 }
 
 impl VM {
-    const FINAL_FP: (Segment, u32) = (4, 0);
-    const FINAL_PC: (Segment, u32) = (5, 0);
+    const FINAL_FP: (Segment, u32) = (3, 0);
+    const FINAL_PC: (Segment, u32) = (4, 0);
 
     pub fn create_for_main_entry_point(program: Program, input: Input) -> Self {
+        let program_segment = 0;
+        let execution_segment = 1;
+        let output_segment = 2;
+
         // Prepare memory.
 
         // Segment 0: program.
-        let program_segment = 0;
         let program_memory_segment =
             program
                 .instructions
                 .iter()
                 .enumerate()
                 .map(|(index, instruction)| {
-                    let instruction_address =
-                        Relocatable::from((program_segment, u32_from_usize(index)));
                     let args = instruction.args;
                     let encoded_instruction =
                         QM31::from_m31_array([instruction.op, args[0], args[1], args[2]]);
+                    let instruction_address =
+                        Relocatable::from((program_segment, u32_from_usize(index)));
 
                     (instruction_address, encoded_instruction)
                 });
         let mut memory = Memory::from_iter(program_memory_segment);
 
         // Segment 1: execution.
-        let execution_segment = 1;
-        let output_segment = 3;
         let execution_memory_segment = [
             // Pointer to output cell.
             ((execution_segment, 0), (output_segment, 0)),
@@ -206,19 +195,7 @@ impl VM {
         .map(|(address, value)| (Relocatable::from(address), Relocatable::from(value)));
         memory.extend(execution_memory_segment);
 
-        // Segment 2: immediates.
-        let immediates_memory_segment =
-            program
-                .immediates
-                .into_iter()
-                .enumerate()
-                .map(|(index, immediate)| {
-                    let immediate_address = immediates_segment_base() + index.into();
-                    (immediate_address, immediate)
-                });
-        memory.extend(immediates_memory_segment);
-
-        // Segments 4, 5: write final `fp`, `pc`.
+        // Segments 3, 4: write final `fp`, `pc`.
         let final_pointers = [
             (Self::FINAL_FP, QM31::zero()),
             (Self::FINAL_PC, QM31::zero()),
@@ -461,10 +438,6 @@ fn opcode_to_instruction(opcode: M31) -> InstructionFn {
     }
 }
 
-pub(crate) fn immediates_segment_base() -> Relocatable {
-    Relocatable::from((IMMEDIATES_SEGMENT, 0))
-}
-
 pub(crate) fn resolve_addresses<const N: usize>(
     state: State,
     bases: &[&str; N],
@@ -475,13 +448,11 @@ pub(crate) fn resolve_addresses<const N: usize>(
         "The number of bases and offsets should not exceed 3"
     );
 
-    let immediates_segment_base = immediates_segment_base().into();
     std::array::from_fn(|i| {
         let base = bases[i];
         let base_address = match base {
             "ap" => state.ap,
             "fp" => state.fp,
-            "imm" => immediates_segment_base,
             _ => panic!("Invalid base: {}", base),
         };
         base_address + offsets[i]

--- a/crates/runnair/src/vm/operand.rs
+++ b/crates/runnair/src/vm/operand.rs
@@ -1,12 +1,8 @@
 use stwo_prover::core::fields::m31::M31;
 
+use super::State;
 use crate::memory::relocatable::assert_and_project;
 use crate::memory::{MaybeRelocatableValue, Memory};
-use crate::vm::{immediates_segment_base, State};
-
-fn read_imm(memory: &Memory, offset: M31) -> MaybeRelocatableValue {
-    memory[immediates_segment_base() + offset]
-}
 
 // Adds:
 pub(crate) fn add_ap_ap(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {
@@ -26,11 +22,11 @@ pub(crate) fn add_fp_fp(memory: &Memory, state: State, args: &[M31]) -> MaybeRel
 }
 
 pub(crate) fn add_imm_ap(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {
-    memory[state.ap + args[1]] + read_imm(memory, args[0])
+    memory[state.ap + args[1]] + args[0]
 }
 
 pub(crate) fn add_imm_fp(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {
-    memory[state.fp + args[1]] + read_imm(memory, args[0])
+    memory[state.fp + args[1]] + args[0]
 }
 
 // Muls:
@@ -51,16 +47,16 @@ pub(crate) fn mul_fp_fp(memory: &Memory, state: State, args: &[M31]) -> MaybeRel
 }
 
 pub(crate) fn mul_imm_ap(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {
-    memory[state.ap + args[1]] * read_imm(memory, args[0])
+    memory[state.ap + args[1]] * args[0]
 }
 
 pub(crate) fn mul_imm_fp(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {
-    memory[state.fp + args[1]] * read_imm(memory, args[0])
+    memory[state.fp + args[1]] * args[0]
 }
 
 // Derefs:
-pub(crate) fn imm(memory: &Memory, _state: State, args: &[M31]) -> MaybeRelocatableValue {
-    read_imm(memory, args[0])
+pub(crate) fn imm(_memory: &Memory, _state: State, args: &[M31]) -> MaybeRelocatableValue {
+    MaybeRelocatableValue::Absolute(args[0].into())
 }
 
 pub(crate) fn deref_ap(memory: &Memory, state: State, args: &[M31]) -> MaybeRelocatableValue {

--- a/crates/runnair/tests/data/fibonacci_compiled.json
+++ b/crates/runnair/tests/data/fibonacci_compiled.json
@@ -37,7 +37,7 @@
         ],
         [
             "0x5a",
-            "0x2",
+            "0x4",
             "0x0",
             "0x0"
         ],
@@ -50,7 +50,7 @@
         [
             "0x1c",
             "0x0",
-            "0x3",
+            "0x2",
             "0x7ffffffc"
         ],
         [
@@ -61,7 +61,7 @@
         ],
         [
             "0xa9",
-            "0x4",
+            "0x3",
             "0x7ffffffc",
             "0x0"
         ],
@@ -104,12 +104,12 @@
         [
             "0x1c",
             "0x0",
-            "0x5",
+            "0x7ffffffe",
             "0x7ffffffc"
         ],
         [
             "0x5a",
-            "0x6",
+            "0x7ffffff7",
             "0x0",
             "0x0"
         ],
@@ -166,25 +166,25 @@
                 "hints": [
                     {
                         "location": {
-                            "end_col": 5,
-                            "end_line": 9,
+                            "end_col": 59,
+                            "end_line": 7,
                             "input_file": {
                                 "filename": "fibonacci.cairo"
                             },
                             "start_col": 3,
                             "start_line": 7
                         },
-                        "n_prefix_newlines": 1
+                        "n_prefix_newlines": 0
                     }
                 ],
                 "inst": {
                     "end_col": 50,
-                    "end_line": 10,
+                    "end_line": 8,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 5,
-                    "start_line": 10
+                    "start_line": 8
                 }
             },
             "2": {
@@ -205,12 +205,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 20,
-                    "end_line": 13,
+                    "end_line": 10,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 19,
-                    "start_line": 13
+                    "start_line": 10
                 }
             },
             "3": {
@@ -231,12 +231,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 23,
-                    "end_line": 13,
+                    "end_line": 10,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 22,
-                    "start_line": 13
+                    "start_line": 10
                 }
             },
             "4": {
@@ -264,12 +264,12 @@
                     "parent_location": [
                         {
                             "end_col": 46,
-                            "end_line": 13,
+                            "end_line": 10,
                             "input_file": {
                                 "filename": "fibonacci.cairo"
                             },
                             "start_col": 25,
-                            "start_line": 13
+                            "start_line": 10
                         },
                         "While expanding the reference 'fibonacci_claim_index' in:"
                     ],
@@ -295,12 +295,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 47,
-                    "end_line": 13,
+                    "end_line": 10,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 15,
-                    "start_line": 13
+                    "start_line": 10
                 }
             },
             "6": {
@@ -322,12 +322,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 32,
-                    "end_line": 14,
+                    "end_line": 11,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 5,
-                    "start_line": 14
+                    "start_line": 11
                 }
             },
             "7": {
@@ -349,12 +349,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 38,
-                    "end_line": 17,
+                    "end_line": 14,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 25,
-                    "start_line": 17
+                    "start_line": 14
                 }
             },
             "8": {
@@ -376,12 +376,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 40,
-                    "end_line": 17,
+                    "end_line": 14,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 5,
-                    "start_line": 17
+                    "start_line": 14
                 }
             },
             "9": {
@@ -403,12 +403,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 7,
-                    "end_line": 21,
+                    "end_line": 18,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 5,
-                    "start_line": 21
+                    "start_line": 18
                 }
             },
             "10": {
@@ -430,24 +430,24 @@
                 "hints": [],
                 "inst": {
                     "end_col": 51,
-                    "end_line": 20,
+                    "end_line": 17,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "parent_location": [
                         {
                             "end_col": 30,
-                            "end_line": 22,
+                            "end_line": 19,
                             "input_file": {
                                 "filename": "fibonacci.cairo"
                             },
                             "start_col": 16,
-                            "start_line": 22
+                            "start_line": 19
                         },
                         "While expanding the reference 'second_element' in:"
                     ],
                     "start_col": 31,
-                    "start_line": 20
+                    "start_line": 17
                 }
             },
             "11": {
@@ -469,12 +469,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 31,
-                    "end_line": 22,
+                    "end_line": 19,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 9,
-                    "start_line": 22
+                    "start_line": 19
                 }
             },
             "12": {
@@ -496,12 +496,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 83,
-                    "end_line": 26,
+                    "end_line": 23,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 54,
-                    "start_line": 26
+                    "start_line": 23
                 }
             },
             "13": {
@@ -524,12 +524,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 117,
-                    "end_line": 26,
+                    "end_line": 23,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 86,
-                    "start_line": 26
+                    "start_line": 23
                 }
             },
             "14": {
@@ -553,24 +553,24 @@
                 "hints": [],
                 "inst": {
                     "end_col": 51,
-                    "end_line": 20,
+                    "end_line": 17,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "parent_location": [
                         {
                             "end_col": 37,
-                            "end_line": 26,
+                            "end_line": 23,
                             "input_file": {
                                 "filename": "fibonacci.cairo"
                             },
                             "start_col": 23,
-                            "start_line": 26
+                            "start_line": 23
                         },
                         "While expanding the reference 'second_element' in:"
                     ],
                     "start_col": 31,
-                    "start_line": 20
+                    "start_line": 17
                 }
             },
             "15": {
@@ -594,12 +594,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 117,
-                    "end_line": 26,
+                    "end_line": 23,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 54,
-                    "start_line": 26
+                    "start_line": 23
                 }
             },
             "16": {
@@ -623,12 +623,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 126,
-                    "end_line": 26,
+                    "end_line": 23,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 121,
-                    "start_line": 26
+                    "start_line": 23
                 }
             },
             "17": {
@@ -652,12 +652,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 6,
-                    "end_line": 27,
+                    "end_line": 24,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 12,
-                    "start_line": 25
+                    "start_line": 22
                 }
             },
             "18": {
@@ -681,12 +681,12 @@
                 "hints": [],
                 "inst": {
                     "end_col": 7,
-                    "end_line": 27,
+                    "end_line": 24,
                     "input_file": {
                         "filename": "fibonacci.cairo"
                     },
                     "start_col": 5,
-                    "start_line": 25
+                    "start_line": 22
                 }
             }
         }
@@ -902,50 +902,6 @@
             "type": "reference"
         }
     },
-    "immediates": [
-        [
-            "0x0",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x1",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x4",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x2",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x3",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x7ffffffe",
-            "0x0",
-            "0x0",
-            "0x0"
-        ],
-        [
-            "0x7ffffff7",
-            "0x0",
-            "0x0",
-            "0x0"
-        ]
-    ],
     "main_scope": "__main__",
     "prime": "0x7fffffff",
     "reference_manager": {


### PR DESCRIPTION
This reverts commit 8eff523112a1d472df81f173392ac643460c02f8.

Complicates bootloader functionality: disallows loading a program from hash (requires to rellocate its immediates, which isn't trivial).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo-m31/32)
<!-- Reviewable:end -->
